### PR TITLE
Docstring wording fixing

### DIFF
--- a/util/mozjpeg_opt.py
+++ b/util/mozjpeg_opt.py
@@ -15,7 +15,7 @@ def mozjpeg_opt(data_org: bytes, executable: str = "mozjpegtran") -> bytes:
 
   Raises:
     OSError: Specified executable or command not found
-    ValueError: Input was not a valid JPEG binary
+    ValueError: Input was invalid JPEG binary
 
   Note:
     It requires mozjpeg's jpegtran executable.
@@ -31,6 +31,6 @@ def mozjpeg_opt(data_org: bytes, executable: str = "mozjpegtran") -> bytes:
   if res.returncode == 127:
     raise OSError("Specified executable or command not found")
   elif res.returncode == 1:
-    raise ValueError("Input was not a valid JPEG binary")
+    raise ValueError("Input was invalid JPEG binary")
 
   return res.stdout


### PR DESCRIPTION
**Description**

Wording fixing in `mozjpeg_opt.py` docstring.

**Details**

Currentry, in `mozjpeg_opt.py` docstring written 'not a valid'.
In `ZipfileMake.py` docstring written 'invalid'.
This difference should be removed.

Changed to 'invalid' to make same wording.

**Checks**

- ~~Check all methods or functions are work collectry and stably~~
- ~~Create testing program~~
- ~~Wrote test cases and steps to test program's docstring~~
- ~~Check all testing program passed~~

Checks skipped because it makes no affects to feature.