### PR TITLE
Test code description was not fixed for 'export_as_download.js' module

### DIFF
--- a/tests/Tests_export_as_download.html
+++ b/tests/Tests_export_as_download.html
@@ -5,7 +5,7 @@
     <script src="../static/export_as_download.js"></script>
     <script>
       /**
-       * Tests for mozjpeg_opt module
+       * Tests for export_as_download.js module
        *
        * Test cases:
        *   * Can export a text file


### PR DESCRIPTION
**Details**

Actually, copy `Tests_mozjpeg_opt.py` module's description to `export_as_download.js` and fix.
Details (Test cases and steps) was fixed, but not head description.
This is for fix it.

**Checks**

- ~~Create or fix test code~~
- ~~The test code can test all methods and functions~~
- ~~Wrote all test cases and steps to test code's head comment~~
- ~~The target program passed all tests~~