### PR TITLE
True cases detection refactored - delete unnecessary `if`

### DIFF
--- a/static/export_as_download.js
+++ b/static/export_as_download.js
@@ -56,9 +56,5 @@ function is_blob_or_file(obj) {
   // Check is in true cases
   let true_cases = ["[object Blob]", "[object File]"];
   let obj_string = obj.toString();
-  if(true_cases.includes(obj_string)) {
-    return true;
-  } else {
-    return false;
-  }
+  return true_cases.includes(obj_string);
 }

--- a/static/files_from_entry.js
+++ b/static/files_from_entry.js
@@ -84,9 +84,5 @@ function is_file_or_directory_entry(obj) {
   let true_cases = ["[object DirectoryEntry]", "[object FileEntry]",
                     "[object FileSystemDirectoryEntry]", "[object FileSystemFileEntry]"];
   let obj_string = obj.toString();
-  if(true_cases.includes(obj_string)) {
-    return true;
-  } else {
-    return false;
-  }
+  return true_cases.includes(obj_string);
 }


### PR DESCRIPTION
**Details**

The code return only `Array.prototype.includes` value.
But unnecessary `if` was there.
Removed them.

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests