### PR TITLE
`FileWithFullPath` removed, alternatery `File` object

### DIFF
--- a/static/files_from_entry.js
+++ b/static/files_from_entry.js
@@ -3,7 +3,7 @@
  *
  * @async
  * @param {FileSystemFileEntry | FileSystemDirectoryEntry} entry File system entry to get all file objects
- * @returns {Promise<Array<FileWithFullpath>>} File objects (with full path) array
+ * @returns {Promise<Array<File>>} File objects (with full path) array
  *
  * @throws {Error} Not enough arguments
  * @throws {Error} `entry` type must be `FileSystemFileEntry` or `FileSystemDirectoryEntry`
@@ -40,26 +40,20 @@ async function files_from_entry(entry) {
     let file = await new Promise(resolve => {
       entry.file(f => { resolve(f); });
     });
-    return [new FileWithFullpath(file, entry.fullPath)];
+    return [file_obj_rename(file, entry.fullPath)];
   }
 }
 
 
-class FileWithFullpath {
-  /**
-   * File containing object to keep full path
-   *
-   * @param {File} file File object to contain
-   * @param {string} fullpath Contained file object's name with full path
-   */
-  constructor(file, fullpath) {
-    this.file = file;
-    this.fullpath = fullpath;
-  }
-
-  toString() {
-    return this.fullpath;
-  }
+/**
+ * Change name field in file object
+ *
+ * @param {File} file File object to rename
+ * @param {string} name New name of file
+ * @returns {File} Renamed file object
+ */
+function file_obj_rename(file, name) {
+  return new File([file], name, {type: file.type, lastModified: file.lastModified});
 }
 
 


### PR DESCRIPTION
**Details**

`File.name` is readonly.
But I found it can change with creating new  `File` object.
So using it, `FileWithFullPath.fullpath` field can contain to `File.name`, and `FileWithFullPath` class can be remove.

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests