### PR TITLE
`Test_ErrCheck_` renamed to `ErrCheck_`

### DIFF
--- a/tests/OnServerTests/Tests_files_from_entry.html
+++ b/tests/OnServerTests/Tests_files_from_entry.html
@@ -42,14 +42,14 @@
         console.log("--- CHECK - Are all files detected?");
       }
 
-      async function Test_ErrCheck_NonEntryInputs() {
+      async function ErrCheck_NonEntryInputs() {
         let test_cases = [{"type": "null", "obj": null},
                           {"type": "number", "obj": 1},
                           {"type": "string", "obj": "hello"},
                           {"type": "function", "obj": () => {}},
                           {"type": "custom_object", "obj": {}}];
         for(const test_case of test_cases) {
-          console.log("-- Test_ErrCheck_NonBlobInput - " + test_case.type)
+          console.log("-- ErrCheck_NonBlobInput - " + test_case.type)
           try {
             await files_from_entry(test_case.obj);
             console.log("--- NG - Error hasn't throwed");
@@ -60,8 +60,8 @@
         }
       }
 
-      async function Test_ErrCheck_NoArgument() {
-        console.log("-- Test_ErrCheck_NoArgument");
+      async function ErrCheck_NoArgument() {
+        console.log("-- ErrCheck_NoArgument");
         try {
           await files_from_entry();
           console.log("--- NG - Error hasn't throwed");
@@ -80,8 +80,8 @@
   <body>
     Test_ReadingFiles: <input type="file" multiple id="Test_ReadingFiles">
     <hr>
-    <input type="button" value="Test_ErrCheck_NonEntryInputs" onclick="Test_ErrCheck_NonEntryInputs()">
+    <input type="button" value="ErrCheck_NonEntryInputs" onclick="ErrCheck_NonEntryInputs()">
     <hr>
-    <input type="button" value="Test_ErrCheck_NoArgument" onclick="Test_ErrCheck_NoArgument()">
+    <input type="button" value="ErrCheck_NoArgument" onclick="ErrCheck_NoArgument()">
   </body>
 </html>

--- a/tests/OnServerTests/Tests_obj_disabling_post.html
+++ b/tests/OnServerTests/Tests_obj_disabling_post.html
@@ -45,14 +45,14 @@
         console.log("--- CHECK2 - Is typed text printed?");
       }
 
-      async function Test_ErrCheck_NonObjectInputs() {
+      async function ErrCheck_NonObjectInputs() {
         let test_cases = [{"type": "null", "obj": null},
                           {"type": "number", "obj": 1},
                           {"type": "string", "obj": "hello"},
                           {"type": "function", "obj": () => {}}];
         for(const test_case of test_cases) {
-          console.log("-- Test_ErrCheck_NonObjectInputs - " + test_case.type);
-          let related_objs = [document.querySelector("#Test_ErrCheck_NonObjectInputs"),
+          console.log("-- ErrCheck_NonObjectInputs - " + test_case.type);
+          let related_objs = [document.querySelector("#ErrCheck_NonObjectInputs"),
                               test_case.obj];
           try {
             await obj_disabling_post("/post_echo_delay", "", related_objs);
@@ -79,6 +79,6 @@
     <textarea placeholder="Any text to post" id="Test_PostWithBody_body"></textarea>
     <input type="button" value="Test_PostWithBody" id="Test_PostWithBody" onclick="Test_PostWithBody()">
     <hr>
-    <input type="button" value="Test_ErrCheck_NonObjectInputs" id="Test_ErrCheck_NonObjectInputs" onclick="Test_ErrCheck_NonObjectInputs()">
+    <input type="button" value="ErrCheck_NonObjectInputs" id="ErrCheck_NonObjectInputs" onclick="ErrCheck_NonObjectInputs()">
   </body>
 </html>

--- a/tests/Tests_ZipfileMake.py
+++ b/tests/Tests_ZipfileMake.py
@@ -100,8 +100,8 @@ def Test_CreateZip_Lzma():
   print("--- OK")
 
 
-def Test_ErrCheck_InvalidCompmode():
-  print("-- Test_ErrCheck_InvalidCompmode")
+def ErrCheck_InvalidCompmode():
+  print("-- ErrCheck_InvalidCompmode")
   try:
     zipfilemake = ZipfileMake("hoge")
     print("--- NG - Exception hasn't raised")
@@ -113,8 +113,8 @@ def Test_ErrCheck_InvalidCompmode():
     print("--- NG - Un expected exception raised")
 
 
-def Test_ErrCheck_InvalidComplevelDeflated():
-  print("-- Test_ErrCheck_InvalidComplevelDeflated")
+def ErrCheck_InvalidComplevelDeflated():
+  print("-- ErrCheck_InvalidComplevelDeflated")
   try:
     zipfilemake = ZipfileMake("deflated", 10)
     print("--- NG - Exception hasn't raised")
@@ -126,8 +126,8 @@ def Test_ErrCheck_InvalidComplevelDeflated():
     print("--- NG - Un expected exception raised")
 
 
-def Test_ErrCheck_InvalidComplevelBzip2():
-  print("-- Test_ErrCheck_InvalidComplevelBzip2")
+def ErrCheck_InvalidComplevelBzip2():
+  print("-- ErrCheck_InvalidComplevelBzip2")
   try:
     zipfilemake = ZipfileMake("bzip2", 10)
     print("--- NG - Exception hasn't raised")
@@ -147,6 +147,6 @@ if __name__ == "__main__":
   Test_CreateZip_Bzip2_Level1()
   Test_CreateZip_Bzip2_Level9()
   Test_CreateZip_Lzma()
-  Test_ErrCheck_InvalidCompmode()
-  Test_ErrCheck_InvalidComplevelDeflated()
-  Test_ErrCheck_InvalidComplevelBzip2()
+  ErrCheck_InvalidCompmode()
+  ErrCheck_InvalidComplevelDeflated()
+  ErrCheck_InvalidComplevelBzip2()

--- a/tests/Tests_export_as_download.html
+++ b/tests/Tests_export_as_download.html
@@ -45,14 +45,14 @@
         console.log("--- CHECK - Is downloading dialog has open? Input file returned as downloading?");
       }
 
-      function Test_ErrCheck_NonBlobInputs() {
+      function ErrCheck_NonBlobInputs() {
         let test_cases = [{"type": "null", "obj": null},
                           {"type": "number", "obj": 1},
                           {"type": "string", "obj": "hello"},
                           {"type": "function", "obj": () => {}},
                           {"type": "custom_object", "obj": {}}];
         test_cases.forEach(test_case => {
-          console.log("-- Test_ErrCheck_NonBlobInput - " + test_case.type);
+          console.log("-- ErrCheck_NonBlobInput - " + test_case.type);
           try {
             export_as_download(test_case.obj);
             console.log("--- NG - Error hasn't throwed");
@@ -63,12 +63,13 @@
         });
       }
 
-      function Test_ErrCheck_NoArgument() {
-        console.log("-- Test_ErrCheck_NoArgument");
+      function ErrCheck_NoArgument() {
+        console.log("-- ErrCheck_NoArgument");
         try {
           export_as_download();
           console.log("--- NG - Error hasn't throwed");
         } catch(e) {
+          er = e;
           console.log(e);
           console.log("--- CHECK - Is the message 'At least 1 argument must be specified, but only 0 passed.'?");
         }
@@ -88,8 +89,8 @@
     Test_ExportCustomFile:
     <input type="file" id="Test_ExportCustomFile">
     <hr>
-    <input type="button" value="Test_ErrCheck_NonBlobInput" onclick="Test_ErrCheck_NonBlobInputs()">
+    <input type="button" value="ErrCheck_NonBlobInput" onclick="ErrCheck_NonBlobInputs()">
     <hr>
-    <input type="button" value="Test_ErrCheck_NoArgument" onclick="Test_ErrCheck_NoArgument()">
+    <input type="button" value="ErrCheck_NoArgument" onclick="ErrCheck_NoArgument()">
   </body>
 </html>

--- a/tests/Tests_jpeg_opt.py
+++ b/tests/Tests_jpeg_opt.py
@@ -47,8 +47,8 @@ def Test_JpegOptimizingMultiple():
   print("--- OK")
 
 
-def Test_ErrCheck_NonJpegInput():
-  print("-- Test_ErrCheck_NonJpegInput")
+def ErrCheck_NonJpegInput():
+  print("-- ErrCheck_NonJpegInput")
   try:
     jpeg_opt(b"a")  # "a" as non jpeg input
     print("--- NG - Exception hasn't raised")
@@ -60,8 +60,8 @@ def Test_ErrCheck_NonJpegInput():
     print("--- NG - Un expected exception raised")
 
 
-def Test_ErrCheck_NonExistCommand():
-  print("-- Test_ErrCheck_NonExistCommand")
+def ErrCheck_NonExistCommand():
+  print("-- ErrCheck_NonExistCommand")
   try:
     org = Part_BinaryFileRead("img.jpg")
     jpeg_opt(org, "a") # "a" as non exist command
@@ -87,5 +87,5 @@ def Part_BinaryFileWrite(file_name: str, file_body: bytes):
 if __name__ == "__main__":
   Test_JpegOptimizing()
   Test_JpegOptimizingMultiple()
-  Test_ErrCheck_NonJpegInput()
-  Test_ErrCheck_NonExistCommand()
+  ErrCheck_NonJpegInput()
+  ErrCheck_NonExistCommand()


### PR DESCRIPTION
**Details**

In test programs, valid input tests `Test_xxx` and invalid input tests `Test_ErrCheck_xxx`.
About error check test, `Test_` prefix isn't necessary.
Removing it, we can distinction valid/invalid tests.

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests