### PR TITLE
Cross top-bottom position fixed, cross size related calc

### DIFF
--- a/static/RemovableList/RemovableList.css
+++ b/static/RemovableList/RemovableList.css
@@ -33,7 +33,7 @@
   position: absolute;
   width: var(--RemovableList-cross-size);
   height: var(--RemovableList-cross-size);
-  top: calc((var(--RemovableList-text-height) - 1em) / 2 + var(--RemovableList-text-padding));
+  top: calc(var(--RemovableList-text-padding) + (var(--RemovableList-text-height) - var(--RemovableList-cross-size)) / 2);
   right: var(--RemovableList-text-padding);
   cursor: pointer;
   opacity: 1;


### PR DESCRIPTION
**Details**

`RemovableList.js` looks work well.
But change `RemovableList-cross-size` in css, cross position be not center of top-bottom.
Fixed it.

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests