### PR TITLE
`RemovableList.count_items` added

### DIFF
--- a/static/RemovableList/RemovableList.js
+++ b/static/RemovableList/RemovableList.js
@@ -177,6 +177,16 @@
 
 
   /**
+   * Get items count in list
+   *
+   * @returns {number} Count of items in list
+   */
+  count_items() {
+    return this.#list_container.children.length;
+  }
+
+
+  /**
    * Remove all items from DOM
    */
   remove_items_all() {


### PR DESCRIPTION
**Details**

A method which returns count of items in list.
It can `export_items_all().length`, but may not goor for performance.
Because the method has array converting, many objects creating.

**Checks**

- [ ] Create or fix test code
- [ ] The test code can test all methods and functions
- [ ] Wrote all test cases and steps to test code's head comment
- [ ] The target program passed all tests