### PR TITLE
Allow return result, even if failed detected in multiple optimizing

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -114,16 +114,31 @@ window.addEventListener("load", () => {
     });
     const res = await fetch("/api/jpegs-opt", {body: post_body, method: "POST"});
 
-    if(res.ok) {
-      // On success, export file as downloading
-      const res_blob = await res.blob();
-      filesList.remove_items_all();
-      CornerMessage.view("Success to process.", CornerMessage.style.info);
-      export_as_download(res_blob, gen_file_name());
-    } else {
-      // On failed, view error message
+    if(Math.floor(res.status / 100) === 4) {
+      // On client error, view error message
       const res_json = await res.json();
       CornerMessage.view("Failed to process:\n" + res_json.detail, CornerMessage.style.danger);
+      filesList.remove_items_all();
+
+    } else if(Math.floor(res.status / 100) === 5) {
+      // On internal server error
+      CornerMessage.view("Failed to process:\nInternal server error");
+
+    } else {
+      // On success, export file as downloading
+      const failed_names = res.headers.get("failed-names");
+      console.log(...res.headers);
+      //// Single file -> null (false)
+      //// Multiples file (and no invalid) -> "" (false)
+      //// Multiples file (with invalid) -> "name1\nname2\n..."
+      if(failed_names) {
+        CornerMessage.view(`Some files failed to process:\n${ array_omit_string(failed_names.split("\n")) }`, CornerMessage.style.warn);
+      } else {
+        CornerMessage.view("Success to process.", CornerMessage.style.info);
+      }
+      filesList.remove_items_all();
+      const res_blob = await res.blob();
+      export_as_download(res_blob, gen_file_name());
     }
 
     controls_unlock(filesList, dropField);

--- a/src/tests/Tests_jpeg_opt.py
+++ b/src/tests/Tests_jpeg_opt.py
@@ -3,13 +3,12 @@
 
 Test cases:
   * Can optimize a JPEG file
-  * Can optimize multiple JPEG files
   * Raise exception when invalid JPEG input
   * Raise exception when invalid executable specified
 
 Test steps:
   1. Set current to this ``tests`` directory
-  2. Create any JPEG file as ``img.jpg`` ``img1.jpg`` ``img2.jpg`` ``img3.jpg``
+  2. Create any JPEG file as ``img1.jpg``
   3. Execute this program
   4. Check console output and follow checking instructions
 
@@ -22,28 +21,15 @@ Author:
 import sys
 sys.path.append("../")
 
-from util.jpeg_opt import jpeg_opt, jpeg_opt_batch
+from util.jpeg_opt import jpeg_opt
 
 
 def Test_JpegOptimizing():
   print("-- Test_JpegOptimizing")
-  org = Part_BinaryFileRead("img.jpg")
+  org = Part_BinaryFileRead("img1.jpg")
   opt = jpeg_opt(org)
   Part_BinaryFileWrite("out.jpg", opt)
   print("--- CHECK - Can out.jpg open")
-
-
-def Test_JpegOptimizingMultiple():
-  print("-- Test_JpegOptimizingMultiple")
-  org = []
-  org.append(Part_BinaryFileRead("img1.jpg"))
-  org.append(Part_BinaryFileRead("img2.jpg"))
-  org.append(Part_BinaryFileRead("img3.jpg"))
-  opt = jpeg_opt_batch(org)
-  Part_BinaryFileWrite("out1.jpg", opt[0])
-  Part_BinaryFileWrite("out2.jpg", opt[1])
-  Part_BinaryFileWrite("out3.jpg", opt[2])
-  print("--- CHECK - Can 'img1.jpg' 'img2.jpg' 'img3.jpg' open")
 
 
 def ErrCheck_NonJpegInput():
@@ -61,7 +47,7 @@ def ErrCheck_NonJpegInput():
 def ErrCheck_NonExistCommand():
   print("-- ErrCheck_NonExistCommand")
   try:
-    org = Part_BinaryFileRead("img.jpg")
+    org = Part_BinaryFileRead("img1.jpg")
     jpeg_opt(org, "a") # "a" as non exist command
     print("--- NG - Exception hasn't raised")
   except OSError as e:
@@ -83,6 +69,5 @@ def Part_BinaryFileWrite(file_name: str, file_body: bytes):
 
 if __name__ == "__main__":
   Test_JpegOptimizing()
-  Test_JpegOptimizingMultiple()
   ErrCheck_NonJpegInput()
   ErrCheck_NonExistCommand()

--- a/src/tests/Tests_jpeg_opt_zipout.py
+++ b/src/tests/Tests_jpeg_opt_zipout.py
@@ -68,6 +68,19 @@ def ErrCheck_AllInvalid():
     print("--- NG - Un expected exception raised")
 
 
+def ErrCheck_NonExistCommand():
+  print("-- ErrCheck_NonExistCommand")
+  files = [UploadFile(open("img1.jpg", "rb"), filename="img1.jpg")]
+  try:
+    zipout, failed_names = jpeg_opt_zipout(files, "a")  # "a" as non exist command
+    print("--- NG - Exception hasn't raised")
+  except OSError as e:
+    print("--- OK")
+  except BaseException as e:
+    print(e)
+    print("--- NG - Un expected exception raised")
+
+
 def Part_BinaryFileWrite(file_name: str, file_body: bytes):
   with open(file_name, "wb") as f:
     f.write(file_body)
@@ -77,3 +90,4 @@ if __name__ == "__main__":
   Test_NoInvalid()
   Test_PartlyInvalid()
   ErrCheck_AllInvalid()
+  ErrCheck_NonExistCommand()

--- a/src/tests/Tests_jpeg_opt_zipout.py
+++ b/src/tests/Tests_jpeg_opt_zipout.py
@@ -5,6 +5,7 @@ Test cases:
   * Can output a zipfile, containing optimized JPEG files
   * Can output failed filenames, when invalid files included
   * Raise exception when no files succeeded to optimize
+  * Raise exception when invalid executable specified
 
 Test steps:
   1. Set current to this ``tests`` directory

--- a/src/tests/Tests_jpeg_opt_zipout.py
+++ b/src/tests/Tests_jpeg_opt_zipout.py
@@ -1,0 +1,79 @@
+# coding: UTF-8
+"""Tests for ``jpeg_opt_zipout.py`` module
+
+Test cases:
+  * Can output a zipfile, containing optimized JPEG files
+  * Can output failed filenames, when invalid files included
+  * Raise exception when no files succeeded to optimize
+
+Test steps:
+  1. Set current to this ``tests`` directory
+  2. Create any JPEG file as ``img1.jpg`` ``img2.jpg`` ``img3.jpg``
+  3. Execute this program
+  4. Check console output and follow checking instructions
+
+Author:
+  aKuad
+
+"""
+
+from fastapi import UploadFile
+
+# For import top layer module
+import sys
+sys.path.append("../")
+
+from util.jpeg_opt_zipout import jpeg_opt_zipout
+
+
+def Test_NoInvalid():
+  print("-- Test_NoInvalid")
+  files = [UploadFile(open("img1.jpg", "rb"), filename="img1.jpg"),
+           UploadFile(open("img2.jpg", "rb"), filename="img2.jpg"),
+           UploadFile(open("img3.jpg", "rb"), filename="dir/img3.jpg")]
+  zipout, failed_names = jpeg_opt_zipout(files)
+  Part_BinaryFileWrite("zipout-noinvalid.zip", zipout)
+  if(len(failed_names) == 0):
+    print("--- CHECK - Is 'zipout-noinvalid.zip' contains 3 jpeg files?")
+  else:
+    print("failed_names: ", failed_names)
+    print("--- NG - Un expected files failed to process")
+
+
+def Test_PartlyInvalid():
+  print("-- Test_PartlyInvalid")
+  files = [UploadFile(open("img1.jpg", "rb"),    filename="img1.jpg"),
+           UploadFile(open("img2.jpg", "rb"),    filename="img2.jpg"),
+           UploadFile(open("invalid.jpg", "rb"), filename="invalid.jpg")]
+  zipout, failed_names = jpeg_opt_zipout(files)
+  Part_BinaryFileWrite("zipout-partly.zip", zipout)
+  if(len(failed_names) == 1 and failed_names[0] == "invalid.jpg"):
+    print("--- CHECK - Is 'zipout-partly.zip' contains 2 jpeg files?")
+  else:
+    print("failed_names: ", failed_names)
+    print("--- NG - Un expected files failed to process")
+
+
+def ErrCheck_AllInvalid():
+  print("-- ErrCheck_AllInvalid")
+  files = [UploadFile(open("invalid.jpg", "rb"), filename="invalid.jpg"),
+           UploadFile(open("invalid.txt", "rb"), filename="invalid.txt")]
+  try:
+    zipout, failed_names = jpeg_opt_zipout(files)
+    print("--- NG - Exception hasn't raised")
+  except ValueError as e:
+    print("--- OK")
+  except Exception as e:
+    print(e)
+    print("--- NG - Un expected exception raised")
+
+
+def Part_BinaryFileWrite(file_name: str, file_body: bytes):
+  with open(file_name, "wb") as f:
+    f.write(file_body)
+
+
+if __name__ == "__main__":
+  Test_NoInvalid()
+  Test_PartlyInvalid()
+  ErrCheck_AllInvalid()

--- a/src/tests/Tests_main_back.py
+++ b/src/tests/Tests_main_back.py
@@ -4,6 +4,7 @@
 Test cases:
   * Can return optimized JPEG from single JPEG
   * Can return optimized JPEG files packed ZIP from multiple JPEG
+  * Can return JPEG file names which failed to process in ``failed-names`` header
   * Return error when non JPEG binary input
   * Return error when invalid JPEG binary input
   * Return error when no name (empty string) file input

--- a/src/tests/Tests_main_back.py
+++ b/src/tests/Tests_main_back.py
@@ -62,6 +62,30 @@ def Test_MultipleProcess():
     print("--- CHECK - Can open res.zip and contains 3 jpeg files")
 
 
+def Test_MultipleProcessIncludingInvalid():
+  print("-- Test_MultipleProcessIncludingInvalid")
+  files = [("files", ("img1.jpg", open("img1.jpg", "rb"), "image/jpeg")),
+           ("files", ("img2.jpg", open("img2.jpg", "rb"), "image/jpeg")),
+           ("files", ("invalid.jpg", open("invalid.jpg", "rb"), "image/jpeg"))]
+  res = requests.post(API_URL, files=files)
+
+  if int(res.status_code / 100) == 5:
+    print(res.content)
+    print("--- NG - Server error")
+  elif int(res.status_code / 100) == 4:
+    print(res.content)
+    print("--- NG - Client error")
+  
+  failed_names = res.headers.get("failed-names").split("\n")
+  if len(failed_names) != 1 or failed_names[0] != "invalid.jpg":
+    print("Expected:", ["invalid.jpg"])
+    print("Actual:", failed_names)
+    print("--- NG - Unexpected header")
+  else:
+    Part_BinaryFileWrite("res-inv.zip", res.content)
+    print("--- CHECK - Can open res-inv.zip and contains 2 jpeg files")
+
+
 def ErrCheck_NonJpeg():
   print("-- ErrCheck_NonJpeg")
   files = [("files", ("invalid.txt", open("invalid.txt", "rb"), "text/plain"))]
@@ -92,6 +116,25 @@ def ErrCheck_InvalidJpeg():
 
   res_dict = json_loads(res.content.decode("utf-8"))
   if res_dict["detail"] == "Invalid jpeg input (may be broken)":
+    print("--- OK")
+  else:
+    print(res.content)
+    print("--- NG - Unexpected error occured")
+
+
+def ErrCheck_InvalidJpegMultiple():
+  print("-- ErrCheck_InvalidJpegMultiple")
+  files = [("files", ("invalid1.jpg", open("invalid.jpg", "rb"), "image/jpeg")),
+           ("files", ("invalid2.jpg", open("invalid.jpg", "rb"), "image/jpeg"))]
+  res = requests.post(API_URL, files=files)
+
+  if int(res.status_code / 100) != 4:
+    print(res.content)
+    print("--- NG - Client error wasn's occured")
+    return
+
+  res_dict = json_loads(res.content.decode("utf-8"))
+  if res_dict["detail"] == "No files could be processed (may be broken)":
     print("--- OK")
   else:
     print(res.content)
@@ -141,7 +184,9 @@ def Part_BinaryFileWrite(file_name: str, file_body: bytes):
 if __name__ == "__main__":
   Test_SingleProcess()
   Test_MultipleProcess()
+  Test_MultipleProcessIncludingInvalid()
   ErrCheck_NonJpeg()
   ErrCheck_InvalidJpeg()
+  ErrCheck_InvalidJpegMultiple()
   ErrCheck_NoNameFile()
   ErrCheck_NoBody()

--- a/src/util/jpeg_opt.py
+++ b/src/util/jpeg_opt.py
@@ -38,34 +38,3 @@ def jpeg_opt(jpeg_in: bytes, executable: str = "jpegtran", options: str = "-opti
     raise ValueError("Input was invalid JPEG binary")
 
   return res.stdout
-
-
-def jpeg_opt_batch(jpegs_in: "list[bytes]", executable: str = "jpegtran", options: str = "-optimize -copy all") -> "list[bytes]":
-  """JPEG optimizing by external command, for multiple files
-
-  Args:
-    jpeg_in (list[bytes]): List of target JPEG binary items
-    executable (str): Executable `jpegtran` path or command
-    options (str): Options to pass executable
-
-  Returns:
-    list[bytes]: Optimized JPEG binary items
-
-  Raises:
-    OSError: Specified executable or command not found
-    ValueError: Input was invalid JPEG binary
-
-  Note:
-    It requires `jpegtran` executable.
-    Put executable into $PATH directory as ``jpegtran``
-      or specify executable path to argument.
-
-  Author:
-    aKuad
-
-  """
-  jpegs_out = []
-  for jpeg_in in jpegs_in:
-    jpegs_out.append(jpeg_opt(jpeg_in, executable, options))
-
-  return jpegs_out

--- a/src/util/jpeg_opt_zipout.py
+++ b/src/util/jpeg_opt_zipout.py
@@ -25,6 +25,7 @@ def jpeg_opt_zipout(files: List[UploadFile], executable: str = "jpegtran", optio
     tuple[bytes, list[str]]: Zip file binary conatins optimized JPEG files & File names which failed to process
 
   Raises:
+    OSError: Specified executable or command not found
     ValueError: No files succeeded to optimize
 
   Author:
@@ -38,7 +39,7 @@ def jpeg_opt_zipout(files: List[UploadFile], executable: str = "jpegtran", optio
     try:
       file_opt = jpeg_opt(file.file.read(), executable, options)
       zipfile.add_file(file.filename, file_opt)
-    except:
+    except ValueError:
       failed_names.append(file.filename)
 
   if len(files) != len(failed_names):

--- a/src/util/jpeg_opt_zipout.py
+++ b/src/util/jpeg_opt_zipout.py
@@ -1,0 +1,47 @@
+# coding: UTF-8
+
+from sys import version_info
+if version_info.minor < 9:
+  from typing import List, Tuple
+else:
+  List = list
+  Tuple = tuple
+
+from fastapi import UploadFile
+
+from .jpeg_opt import jpeg_opt
+from .ZipfileMake import ZipfileMake
+
+
+def jpeg_opt_zipout(files: List[UploadFile], executable: str = "jpegtran", options: str = "-optimize -copy all") -> Tuple[bytes, List[str]]:
+  """Multiple JPEG files optimizing with exporting to a zip file
+
+  Args:
+    files (list[UploadFile]): JPEG files to process
+    executable (str): Executable ``jpegtran`` path or command
+    options (str): Options to pass executable
+
+  Returns:
+    tuple[bytes, list[str]]: Zip file binary conatins optimized JPEG files & File names which failed to process
+
+  Raises:
+    ValueError: No files succeeded to optimize
+
+  Author:
+    aKuad
+
+  """
+  zipfile = ZipfileMake()
+  failed_names: List[str] = []
+
+  for file in files:
+    try:
+      file_opt = jpeg_opt(file.file.read(), executable, options)
+      zipfile.add_file(file.filename, file_opt)
+    except:
+      failed_names.append(file.filename)
+
+  if len(files) != len(failed_names):
+    return zipfile.export_zip(), failed_names
+  else:
+    raise ValueError("All input files were invalid as JPEG")


### PR DESCRIPTION
**Details**

When any files optimizing failed (by invalid jpeg file)...

Currently: Return error 400
Modified: Return zip (uncontained failed files), with failed file names in header

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests