### PR TITLE
Allow same files input

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -54,6 +54,9 @@ window.addEventListener("load", () => {
       return;
     }
 
+    // Allow same imput
+    file_input_reset(event.target);
+
     // If non jpeg files detected, display error message
     const [files_jpeg, files_nojpeg] = names_ext_filter(files_all, ["jpg", "jpeg"]);
     if(files_nojpeg.length !== 0) {

--- a/src/static/index_util.js
+++ b/src/static/index_util.js
@@ -58,3 +58,14 @@ function names_ext_filter(files, expected_exts) {
 
   return [files_ok, files_ng];
 }
+
+
+/**
+ * Reset files input, can be call change event for same input
+ *
+ * @param {HTMLInputElement} input_elem File input element to reset
+ */
+function file_input_reset(input_elem) {
+  input_elem.type = "button";
+  input_elem.type = "file";
+}

--- a/src/tests/Tests_index_util.html
+++ b/src/tests/Tests_index_util.html
@@ -118,8 +118,13 @@
        */
       function Test_file_input_reset() {
         console.log("-- Test_file_input_reset");
-        file_input_reset(document.querySelector("#file_input"));
-        console.log("--- CHECK - Is file selecting been none?");
+        const input_elem = document.querySelector("#file_input");
+        file_input_reset(input_elem);
+        if(input_elem.files.length === 0 && input_elem.webkitEntries.length === 0) {
+          console.log("--- OK");
+        } else {
+          console.log("--- NG - File field wasn't be reset.");
+        }
       }
     </script>
   </head>

--- a/src/tests/Tests_index_util.html
+++ b/src/tests/Tests_index_util.html
@@ -108,6 +108,19 @@
         }
         return true;
       }
+
+
+      /**
+       * `file_input_reset` function
+       *
+       * Test cases:
+       *   * Can set file input to none
+       */
+      function Test_file_input_reset() {
+        console.log("-- Test_file_input_reset");
+        file_input_reset(document.querySelector("#file_input"));
+        console.log("--- CHECK - Is file selecting been none?");
+      }
     </script>
   </head>
 
@@ -118,5 +131,8 @@
     <button onclick="Test_gen_file_name()">Test_gen_file_name</button>
     <hr>
     <button onclick="Test_names_ext_filter()">Test_names_ext_filter</button>
+    <hr>
+    <button onclick="Test_file_input_reset()">Test_file_input_reset</button>
+    <input type="file" multiple id="file_input">
   </body>
 </html>


### PR DESCRIPTION
**Details**

When same files inputted, `change` event won't be called.
By resetting `files` and `webkitEntries` field, it can be resolved.

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests