### PR TITLE
Optimizing-processor modified to parallel

### DIFF
--- a/src/tests/Tests_jpeg_opt_zipout.py
+++ b/src/tests/Tests_jpeg_opt_zipout.py
@@ -55,6 +55,16 @@ def Test_PartlyInvalid():
     print("--- NG - Un expected files failed to process")
 
 
+def Test_HighTuroughput():
+  print("-- Test_HighTuroughput")
+  files = []
+  for i in range(40): # 40 as many (or heavy) files
+    files.append(UploadFile(open("img1.jpg", "rb"), filename=f"img{i}.jpg"))
+  zipout, _ = jpeg_opt_zipout(files)
+  Part_BinaryFileWrite("zipout-throughput.zip", zipout)
+  print("--- CHECK - Was test ended speedy?")
+
+
 def ErrCheck_AllInvalid():
   print("-- ErrCheck_AllInvalid")
   files = [UploadFile(open("invalid.jpg", "rb"), filename="invalid.jpg"),
@@ -90,5 +100,6 @@ def Part_BinaryFileWrite(file_name: str, file_body: bytes):
 if __name__ == "__main__":
   Test_NoInvalid()
   Test_PartlyInvalid()
+  Test_HighTuroughput()
   ErrCheck_AllInvalid()
   ErrCheck_NonExistCommand()

--- a/src/util/jpeg_opt_zipout.py
+++ b/src/util/jpeg_opt_zipout.py
@@ -7,6 +7,8 @@ else:
   List = list
   Tuple = tuple
 
+from concurrent.futures import ThreadPoolExecutor, Future
+
 from fastapi import UploadFile
 
 from .jpeg_opt import jpeg_opt
@@ -32,17 +34,36 @@ def jpeg_opt_zipout(files: List[UploadFile], executable: str = "jpegtran", optio
     aKuad
 
   """
+  # Start processes for optimization
+  ## for compare with non parallel processing:
+  ##   executor = ThreadPoolExecutor(max_workers=1)
+  executor = ThreadPoolExecutor()
+  results: List[Future] = []
+  for file in files:
+    results.append(executor.submit(jpeg_opt_uploadfile, file, executable, options))
+
+  # Pack results to zip file
   zipfile = ZipfileMake()
   failed_names: List[str] = []
-
-  for file in files:
+  for file, result in zip(files, results):
     try:
-      file_opt = jpeg_opt(file.file.read(), executable, options)
-      zipfile.add_file(file.filename, file_opt)
+      file_body = result.result()
+      zipfile.add_file(file.filename, file_body)
     except ValueError:
       failed_names.append(file.filename)
+    except Exception as e:
+      zipfile.export_zip()  # For prevent "Exception ignored - ValueError"
+      raise e
 
+  # Return results
   if len(files) != len(failed_names):
     return zipfile.export_zip(), failed_names
   else:
+    zipfile.export_zip()  # For prevent "Exception ignored - ValueError"
     raise ValueError("All input files were invalid as JPEG")
+
+
+def jpeg_opt_uploadfile(file: UploadFile, executable, options) -> bytes:
+  """Glue code of ``jpeg_opt``, for input UploadFile
+  """
+  return jpeg_opt(file.file.read(), executable, options)

--- a/src/util/jpeg_opt_zipout.py
+++ b/src/util/jpeg_opt_zipout.py
@@ -65,5 +65,10 @@ def jpeg_opt_zipout(files: List[UploadFile], executable: str = "jpegtran", optio
 
 def jpeg_opt_uploadfile(file: UploadFile, executable, options) -> bytes:
   """Glue code of ``jpeg_opt``, for input UploadFile
+
+  Note:
+    It includes file reading process.
+    It makes parallel file reading, and contribute for high throughput.
+
   """
   return jpeg_opt(file.file.read(), executable, options)


### PR DESCRIPTION
**Details**

Currently, `jpegtran` calling was only 1 thread.
Re-implemented by using `concurrent.futures.ThreadPoolExecutor`.

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests