### PR TITLE
Apply auto files renaming to post body, by 'Keep each' function 

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -109,7 +109,7 @@ window.addEventListener("load", () => {
     // Post items to process
     const post_body = new FormData();
     filesList.export_items_all().forEach(e => {
-      post_body.append("files", e.content);
+      post_body.append("files", file_rename(e.content, e.index));
     });
     const res = await fetch("/api/jpegs-opt", {body: post_body, method: "POST"});
 

--- a/src/static/index_util.js
+++ b/src/static/index_util.js
@@ -69,3 +69,21 @@ function file_input_reset(input_elem) {
   input_elem.type = "button";
   input_elem.type = "file";
 }
+
+
+/**
+ * Change name field in file object
+ *
+ * @param {File} file File object to rename
+ * @param {string} new_name New name of file
+ * @returns {File} Renamed file object
+ */
+function file_rename(file, new_name) {
+  if(file.name === new_name) {
+    // If renaming unnecessary, do nothing
+    return file;
+  } else {
+    // Re-creating file object, because name field is read-only
+    return new File([file], new_name, {type: file.type, lastModified: file.lastModified});
+  }
+}

--- a/src/tests/Tests_index_util.html
+++ b/src/tests/Tests_index_util.html
@@ -126,6 +126,25 @@
           console.log("--- NG - File field wasn't be reset.");
         }
       }
+
+
+      /**
+       * `file_rename` function
+       *
+       * Test cases:
+       *   * Can modify `File.name` field
+       */
+      function Test_file_rename() {
+        console.log("-- Test_file_rename");
+        const file = new File(["any-data"], "name-old");
+        const file_re = file_rename(file, "name-new");
+        if(file_re.name === "name-new") {
+          console.log("--- OK");
+        } else {
+          console.log(`Actual: ${ file_re.name }\nExpected: name-new`);
+          console.log("--- NG - Unexpected name");
+        }
+      }
     </script>
   </head>
 
@@ -139,5 +158,7 @@
     <hr>
     <button onclick="Test_file_input_reset()">Test_file_input_reset</button>
     <input type="file" multiple id="file_input">
+    <hr>
+    <button onclick="Test_file_rename()">Test_file_rename</button>
   </body>
 </html>


### PR DESCRIPTION
**Details**

Currently, on file duplicated and choice 'Keep each', index suffix '_n' will be added automatically.
But `File.name` field won't be renamed, including files in post body.
Finally, same name files included in result zip file.

This PR fix it.

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests

For `index.js`, manual checking done.