### PR TITLE
Python tests rewrite using `unittest`

### DIFF
--- a/src/tests/Tests_ZipfileMake.py
+++ b/src/tests/Tests_ZipfileMake.py
@@ -26,124 +26,89 @@ Author:
 
 # For import top layer module
 import sys
-sys.path.append("../")
+from pathlib import Path
+sys.path.append(Path(__file__).absolute().parent.parent.__str__())
+
+import unittest
 
 from util.ZipfileMake import ZipfileMake
 
-
-def Test_CreateZip_Default():
-  print("-- Test_CreateZip_Default")
-  zipfilemake = ZipfileMake()
-  zipfilemake.add_file("hello.txt", "world")
-  zipfilemake.add_file("log/hoge.log", "hoge")
-  with open("default.zip", "wb") as f:
-    f.write(zipfilemake.export_zip())
-  print("--- CHECK - Can 'default.zip' open and containe 2 files")
-
-def Test_CreateZip_Stored():
-  print("-- Test_CreateZip_Stored")
-  zipfilemake = ZipfileMake("stored")
-  zipfilemake.add_file("hello.txt", "world")
-  zipfilemake.add_file("log/hoge.log", "hoge")
-  with open("stored.zip", "wb") as f:
-    f.write(zipfilemake.export_zip())
-  print("--- CHECK - Can 'stored.zip' open and containe 2 files")
+SRC_DIR = Path(__file__).absolute().parent.__str__() + "/"
 
 
-def Test_CreateZip_Deflated_Level0():
-  print("-- Test_CreateZip_Deflated_Level0")
-  zipfilemake = ZipfileMake("deflated", 0)
-  zipfilemake.add_file("hello.txt", "world")
-  zipfilemake.add_file("hoge.log", "hoge")
-  with open("deflated-0.zip", "wb") as f:
-    f.write(zipfilemake.export_zip())
-  print("--- CHECK - Can 'deflated-0.zip' open and containe 2 files")
+class Tests_ZipfileMake(unittest.TestCase):
+  def test_CreateZip_Default(self):
+    zipfilemake = ZipfileMake()
+    zipfilemake.add_file(SRC_DIR + "hello.txt", "world")
+    zipfilemake.add_file(SRC_DIR + "log/hoge.log", "hoge")
+    part_BinaryFileWrite(SRC_DIR + "default.zip", zipfilemake.export_zip())
+    print("[CHECK REQUIRE - Can 'default.zip' open and containe 2 files] ", end="")
 
 
-def Test_CreateZip_Deflated_Level9():
-  print("-- Test_CreateZip_Deflated_Level9")
-  zipfilemake = ZipfileMake("deflated", 9)
-  zipfilemake.add_file("hello.txt", "world")
-  zipfilemake.add_file("hoge.log", "hoge")
-  with open("deflated-9.zip", "wb") as f:
-    f.write(zipfilemake.export_zip())
-  print("--- CHECK - Can 'deflated-9.zip' open and containe 2 files")
+  def test_CreateZip_Stored(self):
+    zipfilemake = ZipfileMake("stored")
+    zipfilemake.add_file(SRC_DIR + "hello.txt", "world")
+    zipfilemake.add_file(SRC_DIR + "log/hoge.log", "hoge")
+    part_BinaryFileWrite(SRC_DIR + "stored.zip", zipfilemake.export_zip())
+    print("[CHECK REQUIRE - Can 'stored.zip' open and containe 2 files] ", end="")
 
 
-def Test_CreateZip_Bzip2_Level1():
-  print("-- Test_CreateZip_Bzip2_Level1")
-  zipfilemake = ZipfileMake("bzip2", 1)
-  zipfilemake.add_file("hello.txt", "world")
-  zipfilemake.add_file("hoge.log", "hoge")
-  with open("bzip2-0.zip", "wb") as f:
-    f.write(zipfilemake.export_zip())
-  print("--- CHECK - Can 'bzip2-0.zip' open and containe 2 files")
+  def test_CreateZip_Deflated_Level0(self):
+    zipfilemake = ZipfileMake("deflated", 0)
+    zipfilemake.add_file(SRC_DIR + "hello.txt", "world")
+    zipfilemake.add_file(SRC_DIR + "hoge.log", "hoge")
+    part_BinaryFileWrite(SRC_DIR + "deflated-0.zip", zipfilemake.export_zip())
+    print("[CHECK REQUIRE - Can 'deflated-0.zip' open and containe 2 files] ", end="")
 
 
-def Test_CreateZip_Bzip2_Level9():
-  print("-- Test_CreateZip_Bzip2_Level9")
-  zipfilemake = ZipfileMake("bzip2", 9)
-  zipfilemake.add_file("hello.txt", "world")
-  zipfilemake.add_file("hoge.log", "hoge")
-  with open("bzip2-9.zip", "wb") as f:
-    f.write(zipfilemake.export_zip())
-  print("--- CHECK - Can 'bzip2-9.zip' open and containe 2 files")
+  def test_CreateZip_Deflated_Level9(self):
+    zipfilemake = ZipfileMake("deflated", 9)
+    zipfilemake.add_file(SRC_DIR + "hello.txt", "world")
+    zipfilemake.add_file(SRC_DIR + "hoge.log", "hoge")
+    part_BinaryFileWrite(SRC_DIR + "deflated-9.zip", zipfilemake.export_zip())
+    print("[CHECK REQUIRE - Can 'deflated-9.zip' open and containe 2 files] ", end="")
 
 
-def Test_CreateZip_Lzma():
-  print("-- Test_CreateZip_Lzma")
-  zipfilemake = ZipfileMake("lzma")
-  zipfilemake.add_file("hello.txt", "world")
-  zipfilemake.add_file("hoge.log", "hoge")
-  with open("lzma.zip", "wb") as f:
-    f.write(zipfilemake.export_zip())
-  print("--- CHECK - Can 'lzma.zip' open and containe 2 files")
+  def test_CreateZip_Bzip2_Level1(self):
+    zipfilemake = ZipfileMake("bzip2", 1)
+    zipfilemake.add_file(SRC_DIR + "hello.txt", "world")
+    zipfilemake.add_file(SRC_DIR + "hoge.log", "hoge")
+    part_BinaryFileWrite(SRC_DIR + "bzip2-0.zip", zipfilemake.export_zip())
+    print("[CHECK REQUIRE - Can 'bzip2-0.zip' open and containe 2 files] ", end="")
 
 
-def ErrCheck_InvalidCompmode():
-  print("-- ErrCheck_InvalidCompmode")
-  try:
-    _ = ZipfileMake("hoge")
-    print("--- NG - Exception hasn't raised")
-  except ValueError as e:
-    print("--- OK")
-  except BaseException as e:
-    print(e)
-    print("--- NG - Un expected exception raised")
+  def test_CreateZip_Bzip2_Level9(self):
+    zipfilemake = ZipfileMake("bzip2", 9)
+    zipfilemake.add_file(SRC_DIR + "hello.txt", "world")
+    zipfilemake.add_file(SRC_DIR + "hoge.log", "hoge")
+    part_BinaryFileWrite(SRC_DIR + "bzip2-9.zip", zipfilemake.export_zip())
+    print("[CHECK REQUIRE - Can 'bzip2-9.zip' open and containe 2 files] ", end="")
 
 
-def ErrCheck_InvalidComplevelDeflated():
-  print("-- ErrCheck_InvalidComplevelDeflated")
-  try:
-    _ = ZipfileMake("deflated", 10)
-    print("--- NG - Exception hasn't raised")
-  except ValueError as e:
-    print("--- OK")
-  except BaseException as e:
-    print(e)
-    print("--- NG - Un expected exception raised")
+  def test_CreateZip_Lzma(self):
+    zipfilemake = ZipfileMake("lzma")
+    zipfilemake.add_file(SRC_DIR + "hello.txt", "world")
+    zipfilemake.add_file(SRC_DIR + "hoge.log", "hoge")
+    part_BinaryFileWrite(SRC_DIR + "lzma.zip", zipfilemake.export_zip())
+    print("[CHECK REQUIRE - Can 'lzma.zip' open and containe 2 files] ", end="")
 
 
-def ErrCheck_InvalidComplevelBzip2():
-  print("-- ErrCheck_InvalidComplevelBzip2")
-  try:
-    _ = ZipfileMake("bzip2", 10)
-    print("--- NG - Exception hasn't raised")
-  except ValueError as e:
-    print("--- OK")
-  except BaseException as e:
-    print(e)
-    print("--- NG - Un expected exception raised")
+  def test_err_InvalidCompmode(self):
+    self.assertRaises(ValueError, ZipfileMake, "hoge")
+
+
+  def test_err_InvalidComplevelDeflated(self):
+    self.assertRaises(ValueError, ZipfileMake, "deflated", 10)
+
+
+  def test_err_InvalidComplevelBzip2(self):
+    self.assertRaises(ValueError, ZipfileMake, "bzip2", 10)
+
+
+def part_BinaryFileWrite(file_name: str, file_body: bytes):
+  with open(file_name, "wb") as f:
+    f.write(file_body)
 
 
 if __name__ == "__main__":
-  Test_CreateZip_Default()
-  Test_CreateZip_Stored()
-  Test_CreateZip_Deflated_Level0()
-  Test_CreateZip_Deflated_Level9()
-  Test_CreateZip_Bzip2_Level1()
-  Test_CreateZip_Bzip2_Level9()
-  Test_CreateZip_Lzma()
-  ErrCheck_InvalidCompmode()
-  ErrCheck_InvalidComplevelDeflated()
-  ErrCheck_InvalidComplevelBzip2()
+  unittest.main(verbosity=2)

--- a/src/tests/Tests_jpeg_opt.py
+++ b/src/tests/Tests_jpeg_opt.py
@@ -19,55 +19,42 @@ Author:
 
 # For import top layer module
 import sys
-sys.path.append("../")
+from pathlib import Path
+sys.path.append(Path(__file__).resolve().parent.parent.__str__())
+
+import unittest
 
 from util.jpeg_opt import jpeg_opt
 
-
-def Test_JpegOptimizing():
-  print("-- Test_JpegOptimizing")
-  org = Part_BinaryFileRead("img1.jpg")
-  opt = jpeg_opt(org)
-  Part_BinaryFileWrite("out.jpg", opt)
-  print("--- CHECK - Can out.jpg open")
+SRC_DIR = Path(__file__).absolute().parent.__str__() + "/"
 
 
-def ErrCheck_NonJpegInput():
-  print("-- ErrCheck_NonJpegInput")
-  try:
-    _ = jpeg_opt(b"a")  # "a" as non jpeg input
-    print("--- NG - Exception hasn't raised")
-  except ValueError as e:
-    print("--- OK")
-  except BaseException as e:
-    print(e)
-    print("--- NG - Un expected exception raised")
+class Tests_jpeg_opt(unittest.TestCase):
+  def test_JpegOptimizing(self):
+    org = part_BinaryFileRead(SRC_DIR + "img1.jpg")
+    opt = jpeg_opt(org)
+    part_BinaryFileWrite(SRC_DIR + "out.jpg", opt)
+    print("CHECK REQUIRE - Can out.jpg open ", end="")
 
 
-def ErrCheck_NonExistCommand():
-  print("-- ErrCheck_NonExistCommand")
-  try:
-    org = Part_BinaryFileRead("img1.jpg")
-    _ = jpeg_opt(org, "a") # "a" as non exist command
-    print("--- NG - Exception hasn't raised")
-  except OSError as e:
-    print("--- OK")
-  except BaseException as e:
-    print(e)
-    print("--- NG - Un expected exception raised")
+  def test_err_NonJpegInput(self):
+    self.assertRaises(ValueError, jpeg_opt, b"a") # b"a" as non jpeg input
 
 
-def Part_BinaryFileRead(file_name: str):
+  def test_err_NonExistCommand(self):
+    org = part_BinaryFileRead(SRC_DIR + "img1.jpg")
+    self.assertRaises(OSError, jpeg_opt, org, "a")
+
+
+def part_BinaryFileRead(file_name: str):
   with open(file_name, "rb") as f:
     return f.read()
 
 
-def Part_BinaryFileWrite(file_name: str, file_body: bytes):
+def part_BinaryFileWrite(file_name: str, file_body: bytes):
   with open(file_name, "wb") as f:
     f.write(file_body)
 
 
 if __name__ == "__main__":
-  Test_JpegOptimizing()
-  ErrCheck_NonJpegInput()
-  ErrCheck_NonExistCommand()
+  unittest.main(verbosity=2)

--- a/src/tests/Tests_jpeg_opt.py
+++ b/src/tests/Tests_jpeg_opt.py
@@ -43,7 +43,7 @@ class Tests_jpeg_opt(unittest.TestCase):
 
   def test_err_NonExistCommand(self):
     org = part_BinaryFileRead(SRC_DIR + "img1.jpg")
-    self.assertRaises(OSError, jpeg_opt, org, "a")
+    self.assertRaises(OSError, jpeg_opt, org, "a")  # "a" as non exist command
 
 
 def part_BinaryFileRead(file_name: str):

--- a/src/tests/Tests_jpeg_opt_zipout.py
+++ b/src/tests/Tests_jpeg_opt_zipout.py
@@ -22,84 +22,62 @@ from fastapi import UploadFile
 
 # For import top layer module
 import sys
-sys.path.append("../")
+from pathlib import Path
+sys.path.append(Path(__file__).absolute().parent.parent.__str__())
+
+import unittest
 
 from util.jpeg_opt_zipout import jpeg_opt_zipout
 
-
-def Test_NoInvalid():
-  print("-- Test_NoInvalid")
-  files = [UploadFile(open("img1.jpg", "rb"), filename="img1.jpg"),
-           UploadFile(open("img2.jpg", "rb"), filename="img2.jpg"),
-           UploadFile(open("img3.jpg", "rb"), filename="dir/img3.jpg")]
-  zipout, failed_names = jpeg_opt_zipout(files)
-  Part_BinaryFileWrite("zipout-noinvalid.zip", zipout)
-  if(len(failed_names) == 0):
-    print("--- CHECK - Is 'zipout-noinvalid.zip' contains 3 jpeg files?")
-  else:
-    print("failed_names: ", failed_names)
-    print("--- NG - Un expected files failed to process")
+SRC_DIR = Path(__file__).absolute().parent.__str__() + "/"
 
 
-def Test_PartlyInvalid():
-  print("-- Test_PartlyInvalid")
-  files = [UploadFile(open("img1.jpg", "rb"),    filename="img1.jpg"),
-           UploadFile(open("img2.jpg", "rb"),    filename="img2.jpg"),
-           UploadFile(open("invalid.jpg", "rb"), filename="invalid.jpg")]
-  zipout, failed_names = jpeg_opt_zipout(files)
-  Part_BinaryFileWrite("zipout-partly.zip", zipout)
-  if(len(failed_names) == 1 and failed_names[0] == "invalid.jpg"):
-    print("--- CHECK - Is 'zipout-partly.zip' contains 2 jpeg files?")
-  else:
-    print("failed_names: ", failed_names)
-    print("--- NG - Un expected files failed to process")
+class Tests_jprg_opt_zipout(unittest.TestCase):
+  def test_NoInvalid(self):
+    files = [UploadFile(open(SRC_DIR + "img1.jpg", "rb"), filename="img1.jpg"),
+             UploadFile(open(SRC_DIR + "img2.jpg", "rb"), filename="img2.jpg"),
+             UploadFile(open(SRC_DIR + "img3.jpg", "rb"), filename="dir/img3.jpg")]
+    zipout, failed_names = jpeg_opt_zipout(files)
+    part_BinaryFileWrite(SRC_DIR + "zipout-noinvalid.zip", zipout)
+    self.assertEqual(len(failed_names), 0)
+    print("CHECK REQUIRE - Is 'zipout-noinvalid.zip' contains 3 jpeg files?", end="")
 
 
-def Test_HighTuroughput():
-  print("-- Test_HighTuroughput")
-  files = []
-  for i in range(40): # 40 as many (or heavy) files
-    files.append(UploadFile(open("img1.jpg", "rb"), filename=f"img{i}.jpg"))
-  zipout, _ = jpeg_opt_zipout(files)
-  Part_BinaryFileWrite("zipout-throughput.zip", zipout)
-  print("--- CHECK - Was test ended speedy?")
+  def test_PartlyInvalid(self):
+    files = [UploadFile(open(SRC_DIR + "img1.jpg", "rb"),    filename="img1.jpg"),
+             UploadFile(open(SRC_DIR + "img2.jpg", "rb"),    filename="img2.jpg"),
+             UploadFile(open(SRC_DIR + "invalid.jpg", "rb"), filename="invalid.jpg")]
+    zipout, failed_names = jpeg_opt_zipout(files)
+    part_BinaryFileWrite(SRC_DIR + "zipout-partly.zip", zipout)
+    self.assertEqual(len(failed_names), 1)
+    self.assertEqual(failed_names[0], "invalid.jpg")
+    print("CHECK REQUIRE - Is 'zipout-partly.zip' contains 2 jpeg files?", end="")
 
 
-def ErrCheck_AllInvalid():
-  print("-- ErrCheck_AllInvalid")
-  files = [UploadFile(open("invalid.jpg", "rb"), filename="invalid.jpg"),
-           UploadFile(open("invalid.txt", "rb"), filename="invalid.txt")]
-  try:
-    _, _ = jpeg_opt_zipout(files)
-    print("--- NG - Exception hasn't raised")
-  except ValueError as e:
-    print("--- OK")
-  except Exception as e:
-    print(e)
-    print("--- NG - Un expected exception raised")
+  def test_HighTuroughput(self):
+    files = []
+    for i in range(40): # 40 as many (or heavy) files
+      files.append(UploadFile(open(SRC_DIR + "img1.jpg", "rb"), filename=f"img{i}.jpg"))
+    zipout, _ = jpeg_opt_zipout(files)
+    part_BinaryFileWrite(SRC_DIR + "zipout-throughput.zip", zipout)
+    print("CHECK REQUIRE - Was test ended speedy?")
 
 
-def ErrCheck_NonExistCommand():
-  print("-- ErrCheck_NonExistCommand")
-  files = [UploadFile(open("img1.jpg", "rb"), filename="img1.jpg")]
-  try:
-    _, _ = jpeg_opt_zipout(files, "a")  # "a" as non exist command
-    print("--- NG - Exception hasn't raised")
-  except OSError as e:
-    print("--- OK")
-  except BaseException as e:
-    print(e)
-    print("--- NG - Un expected exception raised")
+  def test_err_AllInvalid(self):
+    files = [UploadFile(open(SRC_DIR + "invalid.jpg", "rb"), filename="invalid.jpg"),
+             UploadFile(open(SRC_DIR + "invalid.txt", "rb"), filename="invalid.txt")]
+    self.assertRaises(ValueError, jpeg_opt_zipout, files)
 
 
-def Part_BinaryFileWrite(file_name: str, file_body: bytes):
+  def test_err_NonExistCommand(self):
+    files = [UploadFile(open(SRC_DIR + "img1.jpg", "rb"), filename="img1.jpg")]
+    self.assertRaises(OSError, jpeg_opt_zipout, files, "a") # "a" as non exist command
+
+
+def part_BinaryFileWrite(file_name: str, file_body: bytes):
   with open(file_name, "wb") as f:
     f.write(file_body)
 
 
 if __name__ == "__main__":
-  Test_NoInvalid()
-  Test_PartlyInvalid()
-  Test_HighTuroughput()
-  ErrCheck_AllInvalid()
-  ErrCheck_NonExistCommand()
+  unittest.main(verbosity=2)

--- a/src/tests/Tests_jpeg_opt_zipout.py
+++ b/src/tests/Tests_jpeg_opt_zipout.py
@@ -40,7 +40,7 @@ class Tests_jprg_opt_zipout(unittest.TestCase):
     zipout, failed_names = jpeg_opt_zipout(files)
     part_BinaryFileWrite(SRC_DIR + "zipout-noinvalid.zip", zipout)
     self.assertEqual(len(failed_names), 0)
-    print("CHECK REQUIRE - Is 'zipout-noinvalid.zip' contains 3 jpeg files?", end="")
+    print("[CHECK REQUIRE - Is 'zipout-noinvalid.zip' contains 3 jpeg files?] ", end="")
 
 
   def test_PartlyInvalid(self):
@@ -51,7 +51,7 @@ class Tests_jprg_opt_zipout(unittest.TestCase):
     part_BinaryFileWrite(SRC_DIR + "zipout-partly.zip", zipout)
     self.assertEqual(len(failed_names), 1)
     self.assertEqual(failed_names[0], "invalid.jpg")
-    print("CHECK REQUIRE - Is 'zipout-partly.zip' contains 2 jpeg files?", end="")
+    print("[CHECK REQUIRE - Is 'zipout-partly.zip' contains 2 jpeg files?] ", end="")
 
 
   def test_HighTuroughput(self):
@@ -60,7 +60,7 @@ class Tests_jprg_opt_zipout(unittest.TestCase):
       files.append(UploadFile(open(SRC_DIR + "img1.jpg", "rb"), filename=f"img{i}.jpg"))
     zipout, _ = jpeg_opt_zipout(files)
     part_BinaryFileWrite(SRC_DIR + "zipout-throughput.zip", zipout)
-    print("CHECK REQUIRE - Was test ended speedy?")
+    print("[CHECK REQUIRE - Was test ended speedy?] ", end="")
 
 
   def test_err_AllInvalid(self):

--- a/src/tests/Tests_main_back.py
+++ b/src/tests/Tests_main_back.py
@@ -25,151 +25,95 @@ Author:
 from json import loads as json_loads
 import requests
 
+import unittest
+from pathlib import Path
+
+SRC_DIR = Path(__file__).absolute().parent.__str__() + "/"
+
 
 API_URL = "http://localhost:8000/api/jpegs-opt"
 
 
-def Test_SingleProcess():
-  print("-- Test_SingleProcess")
-  files = [("files", ("img1.jpg", open("img1.jpg", "rb"), "image/jpeg"))]
-  res = requests.post(API_URL, files=files)
+class Tests_main_back(unittest.TestCase):
+  def test_SingleProcess(self):
+    files = [("files", ("img1.jpg", open(SRC_DIR + "img1.jpg", "rb"), "image/jpeg"))]
+    res = requests.post(API_URL, files=files)
 
-  if int(res.status_code / 100) == 5:
-    print(res.content)
-    print("--- NG - Server error")
-  elif int(res.status_code / 100) == 4:
-    print(res.content)
-    print("--- NG - Client error")
-  else:
-    Part_BinaryFileWrite("res.jpg", res.content)
-    print("--- CHECK - Was res.jpg created and can open")
+    self.assertEqual(res.status_code // 100, 2, res.content)
+    part_BinaryFileWrite(SRC_DIR + "res.jpg", res.content)
+    print("[CHECK REQUIRE - Was res.jpg created and can open] ", end="")
 
 
-def Test_MultipleProcess():
-  print("-- Test_MultipleProcess")
-  files = [("files", ("img1.jpg", open("img1.jpg", "rb"), "image/jpeg")),
-           ("files", ("img2.jpg", open("img2.jpg", "rb"), "image/jpeg")),
-           ("files", ("img3.jpg", open("img3.jpg", "rb"), "image/jpeg"))]
-  res = requests.post(API_URL, files=files)
+  def test_MultipleProcess(self):
+    files = [("files", ("img1.jpg", open(SRC_DIR + "img1.jpg", "rb"), "image/jpeg")),
+             ("files", ("img2.jpg", open(SRC_DIR + "img2.jpg", "rb"), "image/jpeg")),
+             ("files", ("img3.jpg", open(SRC_DIR + "img3.jpg", "rb"), "image/jpeg"))]
+    res = requests.post(API_URL, files=files)
 
-  if int(res.status_code / 100) == 5:
-    print(res.content)
-    print("--- NG - Server error")
-  elif int(res.status_code / 100) == 4:
-    print(res.content)
-    print("--- NG - Client error")
-  else:
-    Part_BinaryFileWrite("res.zip", res.content)
-    print("--- CHECK - Can open res.zip and contains 3 jpeg files")
+    self.assertEqual(res.status_code // 100, 2, res.content)
+    part_BinaryFileWrite(SRC_DIR + "res.zip", res.content)
+    print("[CHECK REQUIRE - Can open res.zip and contains 3 jpeg files] ", end="")
 
 
-def Test_MultipleProcessIncludingInvalid():
-  print("-- Test_MultipleProcessIncludingInvalid")
-  files = [("files", ("img1.jpg", open("img1.jpg", "rb"), "image/jpeg")),
-           ("files", ("img2.jpg", open("img2.jpg", "rb"), "image/jpeg")),
-           ("files", ("invalid.jpg", open("invalid.jpg", "rb"), "image/jpeg"))]
-  res = requests.post(API_URL, files=files)
+  def test_MultipleProcessIncludingInvalid(self):
+    files = [("files", ("img1.jpg", open(SRC_DIR + "img1.jpg", "rb"), "image/jpeg")),
+             ("files", ("img2.jpg", open(SRC_DIR + "img2.jpg", "rb"), "image/jpeg")),
+             ("files", ("invalid.jpg", open(SRC_DIR + "invalid.jpg", "rb"), "image/jpeg"))]
+    res = requests.post(API_URL, files=files)
 
-  if int(res.status_code / 100) == 5:
-    print(res.content)
-    print("--- NG - Server error")
-  elif int(res.status_code / 100) == 4:
-    print(res.content)
-    print("--- NG - Client error")
-  
-  failed_names = res.headers.get("failed-names").split("\n")
-  if len(failed_names) != 1 or failed_names[0] != "invalid.jpg":
-    print("Expected:", ["invalid.jpg"])
-    print("Actual:", failed_names)
-    print("--- NG - Unexpected header")
-  else:
-    Part_BinaryFileWrite("res-inv.zip", res.content)
-    print("--- CHECK - Can open res-inv.zip and contains 2 jpeg files")
+    self.assertEqual(res.status_code // 100, 2, res.content)
+
+    failed_names = res.headers.get("failed-names").split("\n")
+    self.assertEqual(["invalid.jpg"], failed_names)
+    part_BinaryFileWrite(SRC_DIR + "res-inv.zip", res.content)
+    print("[CHECK REQUIRE - Can open res-inv.zip and contains 2 jpeg files] ", end="")
 
 
-def ErrCheck_NonJpeg():
-  print("-- ErrCheck_NonJpeg")
-  files = [("files", ("invalid.txt", open("invalid.txt", "rb"), "text/plain"))]
-  res = requests.post(API_URL, files=files)
+  def test_err_NonJpeg(self):
+    files = [("files", ("invalid.txt", open(SRC_DIR + "invalid.txt", "rb"), "text/plain"))]
+    res = requests.post(API_URL, files=files)
 
-  if int(res.status_code / 100) != 4:
-    print(res.content)
-    print("--- NG - Client error wasn's occured")
-    return
+    self.assertEqual(res.status_code // 100, 4, "Client error wasn's occured")
 
-  res_dict = json_loads(res.content.decode("utf-8"))
-  if res_dict["detail"] == "Non jpeg input":
-    print("--- OK")
-  else:
-    print(res.content)
-    print("--- NG - Unexpected error occured")
+    res_dict = json_loads(res.content.decode("utf-8"))
+    self.assertEqual(res_dict["detail"], "Non jpeg input", res.content)
 
 
-def ErrCheck_InvalidJpeg():
-  print("-- ErrCheck_InvalidJpeg")
-  files = [("files", ("invalid.jpg", open("invalid.jpg", "rb"), "image/jpeg"))]
-  res = requests.post(API_URL, files=files)
+  def test_err_InvalidJpeg(self):
+    files = [("files", ("invalid.jpg", open(SRC_DIR + "invalid.jpg", "rb"), "image/jpeg"))]
+    res = requests.post(API_URL, files=files)
 
-  if int(res.status_code / 100) != 4:
-    print(res.content)
-    print("--- NG - Client error wasn's occured")
-    return
+    self.assertEqual(res.status_code // 100, 4, "Client error wasn's occured")
 
-  res_dict = json_loads(res.content.decode("utf-8"))
-  if res_dict["detail"] == "Invalid jpeg input (may be broken)":
-    print("--- OK")
-  else:
-    print(res.content)
-    print("--- NG - Unexpected error occured")
+    res_dict = json_loads(res.content.decode("utf-8"))
+    self.assertEqual(res_dict["detail"], "Invalid jpeg input (may be broken)", res.content)
 
 
-def ErrCheck_InvalidJpegMultiple():
-  print("-- ErrCheck_InvalidJpegMultiple")
-  files = [("files", ("invalid1.jpg", open("invalid.jpg", "rb"), "image/jpeg")),
-           ("files", ("invalid2.jpg", open("invalid.jpg", "rb"), "image/jpeg"))]
-  res = requests.post(API_URL, files=files)
+  def test_err_InvalidJpegMultiple(self):
+    files = [("files", ("invalid1.jpg", open(SRC_DIR + "invalid.jpg", "rb"), "image/jpeg")),
+             ("files", ("invalid2.jpg", open(SRC_DIR + "invalid.jpg", "rb"), "image/jpeg"))]
+    res = requests.post(API_URL, files=files)
 
-  if int(res.status_code / 100) != 4:
-    print(res.content)
-    print("--- NG - Client error wasn's occured")
-    return
+    self.assertEqual(res.status_code // 100, 4, "Client error wasn's occured")
 
-  res_dict = json_loads(res.content.decode("utf-8"))
-  if res_dict["detail"] == "No files could be processed (may be broken)":
-    print("--- OK")
-  else:
-    print(res.content)
-    print("--- NG - Unexpected error occured")
+    res_dict = json_loads(res.content.decode("utf-8"))
+    self.assertEqual(res_dict["detail"], "No files could be processed (may be broken)", res.content)
 
 
-def ErrCheck_NoNameFile():
-  print("-- ErrCheck_NoNameFile")
-  files = [("files", ("", open("img1.jpg", "rb"), "image/jpeg"))]
-  res = requests.post(API_URL, files=files)
+  def test_err_NoNameFile(self):
+    files = [("files", ("", open(SRC_DIR + "img1.jpg", "rb"), "image/jpeg"))]
+    res = requests.post(API_URL, files=files)
 
-  if int(res.status_code / 100) != 4:
-    print(res.content)
-    print("--- NG - Client error wasn's occured")
-    return
+    self.assertEqual(res.status_code // 100, 4, "Client error wasn's occured")
 
-  res_dict = json_loads(res.content.decode("utf-8"))
-  if res_dict["detail"] == "Empty filename detected":
-    print("--- OK")
-  else:
-    print(res.content)
-    print("--- NG - Unexpected error occured")
+    res_dict = json_loads(res.content.decode("utf-8"))
+    self.assertEqual(res_dict["detail"], "Empty filename detected", res.content)
 
 
-def Part_BinaryFileWrite(file_name: str, file_body: bytes):
+def part_BinaryFileWrite(file_name: str, file_body: bytes):
   with open(file_name, "wb") as f:
     f.write(file_body)
 
 
 if __name__ == "__main__":
-  Test_SingleProcess()
-  Test_MultipleProcess()
-  Test_MultipleProcessIncludingInvalid()
-  ErrCheck_NonJpeg()
-  ErrCheck_InvalidJpeg()
-  ErrCheck_InvalidJpegMultiple()
-  ErrCheck_NoNameFile()
+  unittest.main(verbosity=2)


### PR DESCRIPTION
**Details**

Previously, no test-frameworks used. Test title and results output written manually.
By using `unittest` module, the status printing code will be unnecessary, and test code can be more compact.

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests
