### PR TITLE
`ZipfileMake` Feature reduce & Prevent handle unclose warn

### DIFF
--- a/src/util/ZipfileMake.py
+++ b/src/util/ZipfileMake.py
@@ -25,7 +25,7 @@ class ZipfileMake:
   '''dict: For convert specified compmode str to int'''
 
 
-  def __init__(self, zip_compmode: str = "stored", zip_complevel: int = None):
+  def __init__(self, zip_compmode: str = "stored", zip_complevel: int | None = None):
     """Constructor
 
     Args:
@@ -39,6 +39,7 @@ class ZipfileMake:
     # Check is compression mode valid
     if self.__ZIP_COMP_DICT.get(zip_compmode) == None:
       raise ValueError("Invalid compression mode specified")
+
     # Check is compression level valid
     if zip_complevel == None:
       pass
@@ -46,7 +47,7 @@ class ZipfileMake:
       raise ValueError("On deflated mode, complession level must be between 0 and 9")
     elif zip_compmode == "bzip2" and (zip_complevel < 1 or zip_complevel > 9):
       raise ValueError("On bzip2 mode, complession level must be between 1 and 9")
-    # Store or create class members
+
     self.__zip_compmode = self.__ZIP_COMP_DICT[zip_compmode]
     self.__zip_complevel = zip_complevel
     self.__fil_handle = TemporaryFile("wb+")

--- a/src/util/ZipfileMake.py
+++ b/src/util/ZipfileMake.py
@@ -80,14 +80,11 @@ class ZipfileMake:
     return self.__fil_handle.read()
 
 
-  # Destructor disabled because of:
-  #   Tried TemporaryFile and ZipFile handles closing in manually.
-  #   But need considering when handles was not created.
-  #   So I trusted handle's auto destruction, to keep this code simple.
-  #
-  # def __del__(self):
-  #   '''Destructor'''
-  #   self.__zip_handle.close()
-  #   del self.__zip_handle
-  #   self.__fil_handle.close()
-  #   del self.__fil_handle
+  def __del__(self):
+    """Destructor
+
+    Release all handles
+
+    """
+    self.__zip_handle.close()
+    self.__fil_handle.close()

--- a/src/util/ZipfileMake.py
+++ b/src/util/ZipfileMake.py
@@ -71,17 +71,13 @@ class ZipfileMake:
     Returns:
       bytes: Created zip archive binary
 
+    Note:
+      After call this, no files can add more.
+
     """
-    # Close ZipFile handle, for read binary
-    self.__zip_handle.close()
-    del self.__zip_handle
-    # Read binary
+    self.__zip_handle.close()   # confirm file binary
     self.__fil_handle.seek(0)
-    ret = self.__fil_handle.read()
-    # Re-open ZipFile handle
-    self.__zip_handle = ZipFile(self.__fil_handle, "a", self.__zip_compmode)
-    # Return
-    return ret
+    return self.__fil_handle.read()
 
 
   # Destructor disabled because of:


### PR DESCRIPTION
**Details**

* After export, zip handle re-open feature remove.
  * It looks unnecessary feature.
  * Keep simple code and tests
* Handle closing added in destructer
  * For prevent resource warning (handle unclosed)

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests
