### PR TITLE
`ZipfileMake` `add_file` type annotation fixed

### DIFF
--- a/src/util/ZipfileMake.py
+++ b/src/util/ZipfileMake.py
@@ -54,7 +54,7 @@ class ZipfileMake:
     self.__zip_handle = ZipFile(self.__fil_handle, "w", self.__zip_compmode, compresslevel=self.__zip_complevel)
 
 
-  def add_file(self, name: str, data: bytes) -> None:
+  def add_file(self, name: str, data: str | bytes) -> None:
     """Add a file to archive from binary
 
     Args:


### PR DESCRIPTION
**Details**

`add_file` method in `ZipfileMake` can support `str` & `bytes`

**Checks**

- ~~Create or fix test code~~
- ~~The test code can test all methods and functions~~
- ~~Wrote all test cases and steps to test code's head comment~~
- ~~The target program passed all tests~~

Checks skipped because it makes no affects to feature.
