### PR TITLE
Remove button modified to `<button>`, for accessibility improvement

### DIFF
--- a/src/static/RemovableList/RemovableList.css
+++ b/src/static/RemovableList/RemovableList.css
@@ -35,6 +35,12 @@
   width: var(--RemovableList-cross-hit);
   height: var(--RemovableList-cross-hit);
 
+  /* Disable <button> original style */
+  font-size: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+
   cursor: pointer;
   opacity: 1;
   transition: opacity 0.2s;

--- a/src/static/RemovableList/RemovableList.js
+++ b/src/static/RemovableList/RemovableList.js
@@ -269,7 +269,7 @@ class RemovableList {
     ele.innerText = index;
 
     // Create and append removing button
-    const ele_cross = document.createElement("div");
+    const ele_cross = document.createElement("button");
     ele_cross.classList.add("RemovableList-cross");
     ele_cross.addEventListener("click", e => {
       e.target.parentNode.remove();


### PR DESCRIPTION
**Details**

An item removing button's HTML element was `<div>`. But for accessibility, `<button>` is better.

This modification be able to control item removing by [Vimium](https://vimium.github.io/).

**Checks**

- [x] Create or fix test code
- [x] The test code can test all methods and functions
- [x] Wrote all test cases and steps to test code's head comment
- [x] The target program passed all tests
